### PR TITLE
Add support for multiple targets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Configuration variables:
 - **save_file_folder**: (Optional) The folder to save processed images to. Note that folder path should be added to [whitelist_external_dirs](https://www.home-assistant.io/docs/configuration/basic/)
 - **save_timestamped_file**: (Optional, default `False`, requires `save_file_folder` to be configured) Save the processed image with the time of detection in the filename.
 - **source**: Must be a camera.
-- **target**: The target object class, default `person`.
+- **target**: The target object class, default `person`. Can also be a list of targets.
 - **confidence**: (Optional) The confidence (in %) above which detected targets are counted in the sensor state. Default value: 80
 - **name**: (Optional) A custom name for the the entity.
 


### PR DESCRIPTION
Adds support for multiple targets provided in a list format in the config. Will match all possible targets above the confidence level and return the total count as the state (also some minor lint and formatting cleanup).

You can now provide multiple targets in the config like this:
```yaml
target: person  # original, still works
# New:
target:
  - person
  - car
  - truck
```

This is my stab at a solution for #70 because I need it for my driveway camera. It's working for me, just wanted to share back if you want to incorporate it. Great work btw!