### PR TITLE
Add image scale option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Configuration variables:
 - **roi_x_max**: (optional, default 1), range 0-1, must be more than roi_x_min
 - **roi_y_min**: (optional, default 0), range 0-1, must be less than roi_y_max
 - **roi_y_max**: (optional, default 1), range 0-1, must be more than roi_y_min
+-  **scale**: (optional, default 1.0), range 0.1-1.0, scaling factor for the images that are pulled from the camera stream. This results in smaller images files, especially when using  hires-cameras.
 - **source**: Must be a camera.
 - **targets**: The list of target object names and/or `object_type`, default `person`. Optionally a `confidence` can be set for this target, if not the default confidence is used. Note the minimum possible confidence is 10%.
 

--- a/custom_components/deepstack_object/image_processing.py
+++ b/custom_components/deepstack_object/image_processing.py
@@ -76,7 +76,7 @@ CONF_ROI_Y_MIN = "roi_y_min"
 CONF_ROI_X_MIN = "roi_x_min"
 CONF_ROI_Y_MAX = "roi_y_max"
 CONF_ROI_X_MAX = "roi_x_max"
-CONF_SCALE= "scale"
+CONF_SCALE = "scale"
 CONF_CUSTOM_MODEL = "custom_model"
 
 DATETIME_FORMAT = "%Y-%m-%d_%H-%M-%S"
@@ -129,7 +129,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_ROI_X_MIN, default=DEFAULT_ROI_X_MIN): cv.small_float,
         vol.Optional(CONF_ROI_Y_MAX, default=DEFAULT_ROI_Y_MAX): cv.small_float,
         vol.Optional(CONF_ROI_X_MAX, default=DEFAULT_ROI_X_MAX): cv.small_float,
-        vol.Optional(CONF_SCALE, default=DEAULT_SCALE): vol.All(vol.Coerce(float, vol.Range(min=0.1, max=1))),
+        vol.Optional(CONF_SCALE, default=DEAULT_SCALE): vol.All(
+            vol.Coerce(float, vol.Range(min=0.1, max=1))
+        ),
         vol.Optional(CONF_SAVE_FILE_FOLDER): cv.isdir,
         vol.Optional(CONF_SAVE_TIMESTAMPTED_FILE, default=False): cv.boolean,
         vol.Optional(CONF_SHOW_BOXES, default=True): cv.boolean,
@@ -303,33 +305,33 @@ class ObjectClassifyEntity(ImageProcessingEntity):
         self._image_height = None
         self._save_file_folder = save_file_folder
         self._save_timestamped_file = save_timestamped_file
-        self._image=None
+        self._image = None
 
     def process_image(self, image):
         """Process an image."""
-        _LOGGER.debug((f"Open image")) 
-        self._image= Image.open(io.BytesIO(bytearray(image))
-        )
-        
+        self._image = Image.open(io.BytesIO(bytearray(image)))
+        _LOGGER.debug((f"Open image"))
         self._image_width, self._image_height = self._image.size
-        
-        #resize image if different then default
-        if self._scale!=DEAULT_SCALE:
-            try: 
-              newsize=(self._image_width*self._scale , self._image_width*self._scale)
-              self._image.thumbnail(newsize,Image.ANTIALIAS)
-              self._image_width,self._image_height =self._image.size
-              with io.BytesIO() as output:
-                self._image.save(output,format="JPEG")
-                image=output.getvalue()
-                _LOGGER.debug((f"Image scaled with : {self._scale} W={self._image_width} H={self._image_height}"))
-            except Exception as err:
-              _LOGGER.error(f"Could not resize to scale : {self._scale} \r\n {err}") 
+
+        # resize image if different then default
+        if self._scale != DEAULT_SCALE:
+            newsize = (self._image_width * self._scale, self._image_width * self._scale)
+            self._image.thumbnail(newsize, Image.ANTIALIAS)
+            self._image_width, self._image_height = self._image.size
+            with io.BytesIO() as output:
+                self._image.save(output, format="JPEG")
+                image = output.getvalue()
+            _LOGGER.debug(
+                (
+                    f"Image scaled with : {self._scale} W={self._image_width} H={self._image_height}"
+                )
+            )
+
         self._state = None
         self._objects = []  # The parsed raw data
         self._targets_found = []
         saved_image_path = None
-    
+
         try:
             predictions = self._dsobject.detect(image)
         except ds.DeepstackException as exc:
@@ -365,7 +367,8 @@ class ObjectClassifyEntity(ImageProcessingEntity):
 
         if self._save_file_folder and self._state > 0:
             saved_image_path = self.save_image(
-                 self._targets_found, self._save_file_folder,
+                self._targets_found,
+                self._save_file_folder,
             )
 
         # Fire events
@@ -432,7 +435,12 @@ class ObjectClassifyEntity(ImageProcessingEntity):
         roi_tuple = tuple(self._roi_dict.values())
         if roi_tuple != DEFAULT_ROI and self._show_boxes:
             draw_box(
-                draw, roi_tuple, img.width, img.height, text="ROI", color=GREEN,
+                draw,
+                roi_tuple,
+                img.width,
+                img.height,
+                text="ROI",
+                color=GREEN,
             )
 
         for obj in targets:

--- a/custom_components/deepstack_object/image_processing.py
+++ b/custom_components/deepstack_object/image_processing.py
@@ -310,7 +310,6 @@ class ObjectClassifyEntity(ImageProcessingEntity):
     def process_image(self, image):
         """Process an image."""
         self._image = Image.open(io.BytesIO(bytearray(image)))
-        _LOGGER.debug((f"Open image"))
         self._image_width, self._image_height = self._image.size
 
         # resize image if different then default


### PR DESCRIPTION
With this change it is possible to scale the received image from a camera entity with a factor (ratio is preserved)

**Note:**  Scale is done before transmitting to deepstack.

Advantages:
- Smaller snapshot file
- Faster processing by deepstack
